### PR TITLE
added jupyter dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Installation
 From PyPI:
 
     pip install nglview
-
+    pip install jupyter
 
 Usage
 =====


### PR DESCRIPTION
I tested the installation on a clean environment (virtualenv) under Python3. Installing jupyter manually turned out to be necessary. After that, it worked out of the box.