### PR TITLE
Bugfix: no trajectory iteration for MDAnalysis Universe.

### DIFF
--- a/nglview/__init__.py
+++ b/nglview/__init__.py
@@ -220,7 +220,7 @@ class MDAnalysisTrajectory(Trajectory, Structure):
 
     def get_coordinates_list(self, index):
         self.atomgroup.universe.trajectory[index]
-        frame = self.atomgroup.positions
+        frame = self.atomgroup.atoms.positions
         return frame.flatten().tolist()
 
     def get_frame_count(self):


### PR DESCRIPTION
When using a MDAnalysis `Universe` object as input for creating an
`MDAnalysisTrajectory` object, iteration through trajectory would not
work. This was due to the fact that a `Universe` has no `positions`
property.

Basically, when I added in the ability to also use `AtomGroup`s in addition to `Universe` objects, I failed to make one additional change to ensure they both work when `get_coordinates_list` is called.