### PR TITLE
fix AttributeError for strip

### DIFF
--- a/nglview/__init__.py
+++ b/nglview/__init__.py
@@ -412,7 +412,11 @@ class NGLWidget(widgets.DOMWidget):
         selection = selection.strip()
 
         for k, v in kwd.items():
-            kwd[k] = v.strip()
+            try:
+                kwd[k] = v.strip()
+            except AttributeError:
+                # e.g.: opacity=0.4
+                kwd[k] = v
 
         rep = self.representations[:]
         d = {'params': {'sele': selection}}


### PR DESCRIPTION
`view.add_representation('surface', opacity=0.4)` will cause AttributeError when trying to use `strip`.

(can use `view.add_representation('surface', opacity="0.4")` too)