### PR TITLE
send and get msg / add representation without clearing

### DIFF
--- a/nglview/__init__.py
+++ b/nglview/__init__.py
@@ -492,6 +492,8 @@ class NGLWidget(widgets.DOMWidget):
         params_list : list of dict
         '''
 
+        if self.representations is params_list:
+            raise ValueError("do not add your self to avoid circular update")
         assert isinstance(params_list, list), 'must provide list of dict'
         if len(params_list) == 0:
             # clearn

--- a/nglview/__init__.py
+++ b/nglview/__init__.py
@@ -414,6 +414,8 @@ class NGLWidget(widgets.DOMWidget):
     coordinates_dict = Dict().tag(sync=True)
     picked = Dict().tag(sync=True)
 
+    _tmp_msg = None
+
     def __init__(self, structure, trajectory=None,
                  representations=None, parameters=None, **kwargs):
         try:
@@ -442,8 +444,9 @@ class NGLWidget(widgets.DOMWidget):
                     "sele": "hetero OR mol"
                 }}
             ]
-        self._add_repr_method_shortcut()
 
+        self._add_repr_method_shortcut()
+        self.on_msg(self._ngl_get_msg)
 
     @property
     def coordinates(self):
@@ -589,6 +592,14 @@ class NGLWidget(widgets.DOMWidget):
         # reassign representation to trigger change
         self.representations = rep
 
+    def _ngl_get_msg(self, widget, msg, buffers):
+        """store message sent from Javascript.
+
+        How? use view.on_msg(get_msg)
+        """
+        import json
+        self._tmp_msg = json.loads(msg)
+        
     def _remote_call(self, method_name, target='stage', args=None, kwargs=None):
         """call NGL's methods from Python.
         

--- a/nglview/__init__.py
+++ b/nglview/__init__.py
@@ -622,13 +622,15 @@ class NGLWidget(widgets.DOMWidget):
                 # e.g.: opacity=0.4
                 kwd[k] = v
 
-        rep = self.representations[:]
         d = {'params': {'sele': selection}}
         d['type'] = repr_type
         d['params'].update(kwd)
-        rep.append(d)
-        # reassign representation to trigger change
-        self.representations = rep
+
+        self._representations.append(d)
+        self._remote_call('addRepresentation',
+                          target='structure_component',
+                          args=[d['type'],],
+                          kwargs=d['params'])
 
     def _ngl_get_msg(self, widget, msg, buffers):
         """store message sent from Javascript.

--- a/nglview/__init__.py
+++ b/nglview/__init__.py
@@ -407,6 +407,7 @@ class NGLWidget(widgets.DOMWidget):
     cache = Bool().tag(sync=True)
     frame = Int().tag(sync=True)
     count = Int().tag(sync=True)
+    _init_representations = List().tag(sync=True)
     structure = Dict().tag(sync=True)
     parameters = Dict().tag(sync=True)
     _coordinates_meta = Dict().tag(sync=True)
@@ -433,13 +434,15 @@ class NGLWidget(widgets.DOMWidget):
                 hasattr(self.trajectory, "n_frames"):
             self.count = self.trajectory.n_frames
 
-        # representations
-        self._representations = []
+        # use _init_representations so we can view representations right after view is made.
+        # self.representations is only have effect if we already call `view`
+        # >>> view = nv.show_pytraj(traj)
+        # >>> view # view.representations = ... does not work at this point, so need to use _init_representations
 
         if representations:
-            self.representations = representations
+            self._ini_representations = representations
         else:
-            self.representations = [
+            self._init_representations = [
                 {"type": "cartoon", "params": {
                     "sele": "polymer"
                 }},
@@ -448,6 +451,8 @@ class NGLWidget(widgets.DOMWidget):
                 }}
             ]
 
+        # keep track but making copy
+        self._representations = self._init_representations[:]
         self._add_repr_method_shortcut()
 
         # register to get data from JS side

--- a/nglview/__init__.py
+++ b/nglview/__init__.py
@@ -606,7 +606,7 @@ class NGLWidget(widgets.DOMWidget):
         Parameters
         ----------
         method_name : str
-        target : str, {'stage', 'viewer', 'component'}
+        target : str, {'stage', 'viewer', 'component', 'structure_component'}
         args : list
         kwargs : dict
             if target is 'component', "component_index" could be passed

--- a/nglview/html/static/widget_ngl.js
+++ b/nglview/html/static/widget_ngl.js
@@ -62,7 +62,7 @@ define( [
             NGL.init( function(){
 
                 // init representations handling
-                this.model.on( "change:representations", this.representationsChanged, this );
+                // this.model.on( "change:representations", this.representationsChanged, this );
 
                 // init structure loading
                 this.model.on( "change:structure", this.structureChanged, this );
@@ -202,16 +202,17 @@ define( [
 
         },
 
-        representationsChanged: function(){
-            var representations = this.model.get( "representations" );
-            var component = this.structureComponent;
-            if( representations && component ){
-                component.clearRepresentations();
-                representations.forEach( function( repr ){
-                    component.addRepresentation( repr.type, repr.params );
-                } );
-            }
-        },
+        // Don't need this anymore, use _remote_call
+        // representationsChanged: function(){
+        //     var representations = this.model.get( "representations" );
+        //     var component = this.structureComponent;
+        //     if( representations && component ){
+        //         component.clearRepresentations();
+        //         representations.forEach( function( repr ){
+        //             component.addRepresentation( repr.type, repr.params );
+        //         } );
+        //     }
+        // },
 
         structureChanged: function(){
             this.structureComponent = undefined;

--- a/nglview/html/static/widget_ngl.js
+++ b/nglview/html/static/widget_ngl.js
@@ -62,7 +62,7 @@ define( [
             NGL.init( function(){
 
                 // init representations handling
-                // this.model.on( "change:representations", this.representationsChanged, this );
+                this.model.on( "change:_init_representations", this.representationsChanged, this );
 
                 // init structure loading
                 this.model.on( "change:structure", this.structureChanged, this );
@@ -202,17 +202,16 @@ define( [
 
         },
 
-        // Don't need this anymore, use _remote_call
-        // representationsChanged: function(){
-        //     var representations = this.model.get( "representations" );
-        //     var component = this.structureComponent;
-        //     if( representations && component ){
-        //         component.clearRepresentations();
-        //         representations.forEach( function( repr ){
-        //             component.addRepresentation( repr.type, repr.params );
-        //         } );
-        //     }
-        // },
+        representationsChanged: function(){
+            var representations = this.model.get( "_init_representations" );
+            var component = this.structureComponent;
+            if( representations && component ){
+                component.clearRepresentations();
+                representations.forEach( function( repr ){
+                    component.addRepresentation( repr.type, repr.params );
+                } );
+            }
+        },
 
         structureChanged: function(){
             this.structureComponent = undefined;

--- a/nglview/html/static/widget_ngl.js
+++ b/nglview/html/static/widget_ngl.js
@@ -357,6 +357,10 @@ define( [
                        var component = this.stage.compList[index];
                        var func = component[msg.methodName];
                        func.apply( component, new_args );
+               }else if( msg.target == 'structure_component' ){
+                       var component = this.structureComponent;
+                       var func = component[msg.methodName];
+                       func.apply( component, new_args );
                }
            }else if( msg.type == 'base64' ){
                console.log( "receiving base64 dict" );

--- a/nglview/html/static/widget_ngl.js
+++ b/nglview/html/static/widget_ngl.js
@@ -369,6 +369,12 @@ define( [
                for (var i = 0; i < Object.keys(base64Dict).length; i++) {
                     this.coordsDict[i] = this.mydecode( base64Dict[i]);
                }
+           }else if( msg.type == 'get') {
+               console.log( msg.data );
+
+               if( msg.data == 'camera' ) {
+                   this.send( JSON.stringify( this.stage.viewer.camera ) );
+               }
            }
     },
     } );

--- a/nglview/tests/notebooks/representations.ipynb
+++ b/nglview/tests/notebooks/representations.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },

--- a/nglview/tests/notebooks/representations.ipynb
+++ b/nglview/tests/notebooks/representations.ipynb
@@ -1,0 +1,139 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import pytraj as pt\n",
+    "import nglview as nv\n",
+    "\n",
+    "traj = pt.datafiles.load_tz2()\n",
+    "view = nv.show_pytraj(traj)\n",
+    "view"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "view.add_cartoon()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "view.add_rope()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "view.add_line()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "view.add_licorice(color='residueindex')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "view.representations = []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "view.add_line()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'params': {'sele': 'polymer'}, 'type': 'cartoon'},\n",
+       " {'params': {'sele': 'hetero OR mol'}, 'type': 'ball+stick'},\n",
+       " {'params': {'sele': 'polymer'}, 'type': 'cartoon'},\n",
+       " {'params': {'sele': 'hetero OR mol'}, 'type': 'ball+stick'},\n",
+       " {'params': {'sele': 'all'}, 'type': 'cartoon'},\n",
+       " {'params': {'sele': 'polymer'}, 'type': 'cartoon'},\n",
+       " {'params': {'sele': 'hetero OR mol'}, 'type': 'ball+stick'},\n",
+       " {'params': {'sele': 'polymer'}, 'type': 'cartoon'},\n",
+       " {'params': {'sele': 'hetero OR mol'}, 'type': 'ball+stick'},\n",
+       " {'params': {'sele': 'all'}, 'type': 'cartoon'},\n",
+       " {'params': {'sele': 'all'}, 'type': 'cartoon'}]"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "view.representations"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nglview/tests/notebooks/representations.ipynb
+++ b/nglview/tests/notebooks/representations.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 19,
    "metadata": {
     "collapsed": true
    },
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 20,
    "metadata": {
     "collapsed": true
    },
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 21,
    "metadata": {
     "collapsed": true
    },
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 22,
    "metadata": {
     "collapsed": true
    },
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 16,
    "metadata": {
     "collapsed": false
    },
@@ -73,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 17,
    "metadata": {
     "collapsed": true
    },
@@ -84,34 +84,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[{'params': {'sele': 'polymer'}, 'type': 'cartoon'},\n",
-       " {'params': {'sele': 'hetero OR mol'}, 'type': 'ball+stick'},\n",
-       " {'params': {'sele': 'polymer'}, 'type': 'cartoon'},\n",
-       " {'params': {'sele': 'hetero OR mol'}, 'type': 'ball+stick'},\n",
-       " {'params': {'sele': 'all'}, 'type': 'cartoon'},\n",
-       " {'params': {'sele': 'polymer'}, 'type': 'cartoon'},\n",
-       " {'params': {'sele': 'hetero OR mol'}, 'type': 'ball+stick'},\n",
-       " {'params': {'sele': 'polymer'}, 'type': 'cartoon'},\n",
-       " {'params': {'sele': 'hetero OR mol'}, 'type': 'ball+stick'},\n",
-       " {'params': {'sele': 'all'}, 'type': 'cartoon'},\n",
-       " {'params': {'sele': 'all'}, 'type': 'cartoon'}]"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "view.representations"
+    "view.representations = []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "nv.show_structure_file('tz2.pdb')"
    ]
   }
  ],

--- a/nglview/tests/test_widget.py
+++ b/nglview/tests/test_widget.py
@@ -160,8 +160,8 @@ def test_speed():
 
     from pytraj.testing import get_fn, Timer
     traj = pt.datafiles.load_tz2_ortho()
-    fname_tuple = ([traj.filename, traj.top.filename, 1000],
-                   [nv.datafiles.TRR, nv.datafiles.PDB, 100])
+    fname_tuple = ([traj.filename, traj.top.filename, 100],
+                   [nv.datafiles.TRR, nv.datafiles.PDB, 10])
 
     for (fn, tn, n_files) in fname_tuple:
         traj = pt.load([fn,]*n_files, tn)

--- a/nglview/tests/test_widget.py
+++ b/nglview/tests/test_widget.py
@@ -64,6 +64,30 @@ def teardown():
 # NGLView stuff
 #-----------------------------------------------------------------------------
 
+def _assert_dict_list_equal(listdict0, listdict1):
+    for (dict0, dict1) in zip(listdict0, listdict1):
+        for (key0, key1) in zip(sorted(dict0.keys()), sorted(dict1.keys())):
+            nt.assert_equal(key0, key1)
+            nt.assert_equal(dict0.get(key0), dict1.get(key1))
+
+def test_representations():
+    view = nv.show_pytraj(pt.datafiles.load_tz2())
+    representations = [
+                {"type": "cartoon", "params": {
+                    "sele": "polymer"
+                }},
+                {"type": "ball+stick", "params": {
+                    "sele": "hetero OR mol"
+                }}]
+    nt.assert_equal(view.representations, representations)
+    view.add_cartoon()
+    representations_2 = representations[:]
+    representations_2.append({'type': 'cartoon', 'params': {'sele': 'all'}})
+    print(representations_2)
+    print(view.representations)
+    _assert_dict_list_equal(view.representations, representations_2)
+                    
+
 def test_add_repr_shortcut():
     view = nv.show_pytraj(pt.datafiles.load_tz2())
     assert isinstance(view, nv.NGLWidget), 'must be instance of NGLWidget'

--- a/nglview/tests/test_widget.py
+++ b/nglview/tests/test_widget.py
@@ -64,6 +64,9 @@ def teardown():
 # NGLView stuff
 #-----------------------------------------------------------------------------
 
+DEFAULT_REPR = [{'params': {'sele': 'polymer'}, 'type': 'cartoon'},
+                {'params': {'sele': 'hetero OR mol'}, 'type': 'ball+stick'}]
+
 def _assert_dict_list_equal(listdict0, listdict1):
     for (dict0, dict1) in zip(listdict0, listdict1):
         for (key0, key1) in zip(sorted(dict0.keys()), sorted(dict1.keys())):
@@ -72,16 +75,9 @@ def _assert_dict_list_equal(listdict0, listdict1):
 
 def test_representations():
     view = nv.show_pytraj(pt.datafiles.load_tz2())
-    representations = [
-                {"type": "cartoon", "params": {
-                    "sele": "polymer"
-                }},
-                {"type": "ball+stick", "params": {
-                    "sele": "hetero OR mol"
-                }}]
-    nt.assert_equal(view.representations, representations)
+    nt.assert_equal(view.representations, DEFAULT_REPR)
     view.add_cartoon()
-    representations_2 = representations[:]
+    representations_2 = DEFAULT_REPR[:]
     representations_2.append({'type': 'cartoon', 'params': {'sele': 'all'}})
     print(representations_2)
     print(view.representations)
@@ -103,7 +99,10 @@ def test_remote_call():
     kwargs = {'defaultRepresentation': True}
     view._remote_call('loadFile', target='stage', args=[fn,], kwargs=kwargs)
 
-# @unittest.skip("mess up with scipy, skip mdtraj now")
+
+def test_show_structure_file():
+    view = nv.show_structure_file(nv.datafiles.PDB)
+
 def test_show_mdtraj():
     import mdtraj as md
     from mdtraj.testing import get_fn


### PR DESCRIPTION
- add `_ngl_get_msg` to send a message to JS and get back the data

- add timing to send bytes, base64, ...

- add calling 'structureComponent' to call `addRepresentation` to avoid re-rendering.
address issue 
```python
view._remote_call('addRepresentation', target='structure_component', args=['cartoon'])
```

https://github.com/arose/nglview/issues/24