### PR TITLE
use ipywidgets < 5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ if __name__ == '__main__':
             "nglview.html": ["static/*"]
         },
         packages=["nglview", "nglview.datafiles", "nglview.html"],
-        install_requires=["jupyter", "traitlets>=4.2.1"],
+        install_requires=["jupyter", "traitlets>=4.2.1", "ipywidgets<5.0"],
         tests_require=["nose"],
         test_suite="nose.collector",
         extras_require={


### PR DESCRIPTION
@arose I got big trouble upgrading to ipywidgets >= 5.0. (can not display NGLWidget). Mostly due to this: https://github.com/ipython/ipywidgets/wiki/ipywidgets-5.0-Release-Document

Will wait until it has stable API + you're available to update JS config.