### PR TITLE
fix representation initialization

### DIFF
--- a/nglview/html/static/widget_ngl.js
+++ b/nglview/html/static/widget_ngl.js
@@ -108,6 +108,8 @@ define( [
                     this.$container.resizable(
                         "option", "maxWidth", this.$el.parent().width()
                     );
+                    this.model.set('loaded', true);
+                    this.touch();
                 }.bind( this ) );
 
                 // init toggle fullscreen

--- a/nglview/tests/notebooks/init_representations.ipynb
+++ b/nglview/tests/notebooks/init_representations.ipynb
@@ -1,0 +1,65 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import pytraj as pt\n",
+    "import nglview as nv\n",
+    "\n",
+    "traj = pt.datafiles.load_tz2()\n",
+    "view = nv.show_pytraj(traj)\n",
+    "view.add_licorice() # make sure this will be displayed\n",
+    "view"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "assert view.loaded == True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "assert view.displayed == True"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nglview/tests/notebooks/representations.ipynb
+++ b/nglview/tests/notebooks/representations.ipynb
@@ -133,7 +133,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.4"
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Before, this code does not update `licorice` because it won't be called before the widget is displayed.

```python
view = nv.show_pytraj(...)
view.add_licorice()
view
```

so we need to

```python
view = nv.show_pytraj(...)
view

view.add_licorice()
```

However, we add all `_remote_call` to a list and call each function right after the Widget is created and displayed. which make 1st code works.

**Credit**: learn a lot from [chemview](https://github.com/gabrielelanaro/chemview/blob/master/chemview/widget.py)