### PR TITLE
add load_dx notebook + add ext option

### DIFF
--- a/nglview/__init__.py
+++ b/nglview/__init__.py
@@ -64,7 +64,10 @@ def show_structure_file(path, **kwargs):
     >>> w = nv.show_structure_file(nv.datafiles.GRO)
     >>> w
     '''
-    extension = os.path.splitext(path)[1][1:]
+    if 'ext' in kwargs:
+        extension = kwargs.pop('ext')
+    else:
+        extension = os.path.splitext(path)[1][1:]
     structure = FileStructure(path, ext=extension)
     return NGLWidget(structure, **kwargs)
 

--- a/nglview/tests/notebooks/load_dx.ipynb
+++ b/nglview/tests/notebooks/load_dx.ipynb
@@ -1,0 +1,83 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import pytraj as pt, nglview as nv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "view = nv.show_structure_file('volmap.dx.save', \n",
+    "                              ext='dx', \n",
+    "                              representations=[{'type': 'surface'}])\n",
+    "view"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "view.add_surface(colorScheme='uniform', colorValue='red', boxSize=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "view._load_data(open('../tz2.pdb').read(), ext='pdb')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "view.add_cartoon(color='blue', index=1)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
```python
view = nv.show_structure_file('volmap.dx.save', 
                              ext='dx', 
                              representations=[{'type': 'surface'}])
```

so we don't need to rename the file. :D 

of course, if no `ext` is provided, NGL will take '.save` as ext.