### PR TITLE
make simpletraj interface consistent with the rest (pytraj/mdtraj/MDA...)

### DIFF
--- a/nglview/__init__.py
+++ b/nglview/__init__.py
@@ -74,7 +74,7 @@ def show_structure_file(path, **kwargs):
     return NGLWidget(structure, **kwargs)
 
 
-def show_simpletraj(structure_path, trajectory_path, **kwargs):
+def show_simpletraj(traj, **kwargs):
     '''Show simpletraj trajectory and structure file.
 
     Example
@@ -83,10 +83,7 @@ def show_simpletraj(structure_path, trajectory_path, **kwargs):
     >>> w = nv.show_simpletraj(nv.datafiles.GRO, nv.datafiles.XTC)
     >>> w
     '''
-    extension = os.path.splitext(structure_path)[1][1:]
-    structure = FileStructure(structure_path, ext=extension)
-    trajectory = SimpletrajTrajectory(trajectory_path)
-    return NGLWidget(structure, trajectory, **kwargs)
+    return NGLWidget(traj, **kwargs)
 
 
 def show_mdtraj(mdtraj_trajectory, **kwargs):
@@ -220,7 +217,7 @@ class SimpletrajTrajectory(Trajectory, Structure):
     >>> w = nv.NGLWidget(t)
     >>> w
     '''
-    def __init__(self, path, topology_path):
+    def __init__(self, path, structure_path):
         try:
             import simpletraj
         except ImportError as e:
@@ -229,7 +226,10 @@ class SimpletrajTrajectory(Trajectory, Structure):
             )
         self.traj_cache = simpletraj.trajectory.TrajectoryCache()
         self.path = path
-        self._topology_path = topology_path
+        self._structure_path = structure_path
+        self.ext = os.path.splitext(structure_path)[1][1:]
+        self.params = {}
+        self.trajectory = None
         try:
             self.traj_cache.get(os.path.abspath(self.path))
         except Exception as e:
@@ -250,7 +250,7 @@ class SimpletrajTrajectory(Trajectory, Structure):
         return coordinates_dict
 
     def get_structure_string(self):
-        return open(self._topology_path).read()
+        return open(self._structure_path).read()
 
     @property
     def n_frames(self):

--- a/nglview/tests/notebooks/test_simpletraj.ipynb
+++ b/nglview/tests/notebooks/test_simpletraj.ipynb
@@ -1,0 +1,108 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<nglview.SimpletrajTrajectory at 0x2aaacbc31e48>"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import nglview as nv\n",
+    "\n",
+    "fn, tn = nv.datafiles.XTC, nv.datafiles.GRO\n",
+    "\n",
+    "traj = nv.SimpletrajTrajectory(fn, tn)\n",
+    "traj"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "view = nv.show_simpletraj(traj)\n",
+    "view"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "view.caching()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "view._clear_repr()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "view.add_cartoon()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "view.add_rope()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nglview/tests/notebooks/trajlist_parmed.ipynb
+++ b/nglview/tests/notebooks/trajlist_parmed.ipynb
@@ -1,0 +1,101 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import parmed as pmd\n",
+    "from pytraj.testing import get_fn\n",
+    "import  nglview as nv\n",
+    "\n",
+    "fn, tn = get_fn('trpcage')\n",
+    "parm0 = pmd.load_file(tn, fn)\n",
+    "fn, tn = get_fn('tz2_dry')\n",
+    "parm1 = pmd.load_file(tn, fn)\n",
+    "\n",
+    "trajlist = [nv.ParmEdTrajectory(parm) for parm in [parm0, parm1]]\n",
+    "\n",
+    "trajlist\n",
+    "\n",
+    "view = nv.NGLWidget(trajlist)\n",
+    "view"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# try cache\n",
+    "view.caching()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "view.uncaching()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[array([], dtype=float32), array([[  2.56800008,  12.35900021,   0.093     ],\n",
+       "        [  2.4519999 ,  12.64799976,   1.05299997],\n",
+       "        [  3.43899989,  11.84700012,   0.105     ],\n",
+       "        ..., \n",
+       "        [  7.75600004,  -9.58300018,   3.98699999],\n",
+       "        [  6.70900011, -10.35000038,   5.08199978],\n",
+       "        [  7.40799999, -11.18200016,   3.5940001 ]], dtype=float32)]"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "view.coordinates"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nglview/tests/notebooks/trajlist_pytraj.ipynb
+++ b/nglview/tests/notebooks/trajlist_pytraj.ipynb
@@ -154,7 +154,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.4.4"
   }
  },
  "nbformat": 4,

--- a/nglview/tests/notebooks/trajlist_simpletraj.ipynb
+++ b/nglview/tests/notebooks/trajlist_simpletraj.ipynb
@@ -1,0 +1,106 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(<nglview.SimpletrajTrajectory at 0x2aaacd558b70>,\n",
+       " <nglview.SimpletrajTrajectory at 0x2aaacd544f98>)"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import nglview as nv\n",
+    "from pytraj.testing import get_fn\n",
+    "import pytraj as pt\n",
+    "\n",
+    "fn, tn = get_fn('tz2_dry')\n",
+    "\n",
+    "# I am to lazy\n",
+    "pt.load(fn, tn)[:1].save('../data/tz2.single.pdb', overwrite=True)\n",
+    "pt.load(fn, tn).save('../tz2.nc', overwrite=True)\n",
+    "\n",
+    "traj = nv.SimpletrajTrajectory(nv.datafiles.XTC, nv.datafiles.GRO)\n",
+    "traj2 = nv.SimpletrajTrajectory('../data/tz2.nc', '../data/tz2.single.pdb')\n",
+    "\n",
+    "traj, traj2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "view = nv.NGLWidget([traj, traj2])\n",
+    "view"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "view.caching()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "view.add_cartoon(model=1, color='residueindex')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "view.add_licorice(model=1)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
```python
fn, tn = nv.datafiles.XTC, nv.datafiles.GRO
traj = nv.SimpletrajTrajectory(fn, tn)
view = nv.show_simpletraj(traj)
view
```

So now we can view more than 1 simpletraj's trajectories in the same widget too.

![simpletraj](https://cloud.githubusercontent.com/assets/4451957/15063984/32b1fcca-131d-11e6-9c29-8b88aaa28e38.png)
