### PR TITLE
Revert "remove binder link since the widget won't be displayed."

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 
+[![Binder](http://mybinder.org/images/logo.svg)](http://mybinder.org/repo/hainm/nglview-notebooks)
 [![DOI](https://zenodo.org/badge/11846/arose/nglview.svg)](https://zenodo.org/badge/latestdoi/11846/arose/nglview)
 [![Build Status](https://travis-ci.org/arose/nglview.svg?branch=master)](https://travis-ci.org/arose/nglview)
 


### PR DESCRIPTION
Reverts arose/nglview#215 since I fixed it