### PR TITLE
Update README.md: move `membrane` simulation up. I think it looks nicer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,13 @@
 [![Binder](http://mybinder.org/images/logo.svg)](http://mybinder.org/repo/hainm/nglview-notebooks)
 [![DOI](https://zenodo.org/badge/11846/arose/nglview.svg)](https://zenodo.org/badge/latestdoi/11846/arose/nglview)
 [![Build Status](https://travis-ci.org/arose/nglview.svg?branch=master)](https://travis-ci.org/arose/nglview)
-
-![nglview](nglview.gif)
-
+![membrane](examples/images/membrane.gif)
 
 An [IPython/Jupyter](http://jupyter.org/) widget to interactively view molecular structures and trajectories. Utilizes the embeddable [NGL Viewer](https://github.com/arose/ngl) for rendering. Support for showing data from the file-system, [RCSB PDB](http:www.rcsb.org), [simpletraj](https://github.com/arose/simpletraj) and from objects of analysis libraries [mdtraj](http://mdtraj.org/), [pytraj](http://amber-md.github.io/pytraj/latest/index.html), [mdanalysis](http://www.mdanalysis.org/).
 
 Should work with Python 2 and 3. If you experience problems, please file an [issue](https://github.com/arose/nglview/issues).
 
-![membrane](examples/images/membrane.gif)
+![nglview](nglview.gif)
 
 
 Table of contents


### PR DESCRIPTION
move `membrane` simulation up. I think it looks nicer.