### PR TITLE
force to use notebook < 4.2

### DIFF
--- a/devtools/travis-ci/conda-recipe/meta.yaml
+++ b/devtools/travis-ci/conda-recipe/meta.yaml
@@ -8,6 +8,7 @@ requirements:
     - setuptools
     - jupyter
     - ipywidgets <=4.1.1
+    - notebook <=4.1
     - traitlets
   run:
     - python
@@ -15,7 +16,7 @@ requirements:
     - ipywidgets <=4.1.1
     - jupyter
     - traitlets
-    - notebook
+    - notebook <=4.1
 
 test:
     imports:

--- a/nglview/scripts/nglview.py
+++ b/nglview/scripts/nglview.py
@@ -126,6 +126,7 @@ def main(notebook_dict=notebook_dict):
     parser.add_argument('--port', type=int, help='port number')
     parser.add_argument('--remote', action='store_true', help='create remote notebook')
     parser.add_argument('--clean-cache', action='store_true', help='delete temp file after closing notebook')
+    parser.add_argument('--disable-autorun', action='store_true', help='do not run 1st cell right after openning notebook')
     args = parser.parse_args()
 
     command = parm = args.command
@@ -176,7 +177,8 @@ def main(notebook_dict=notebook_dict):
                                                                     port=port)
         print('NOTE: make sure to open {0} in your local machine\n'.format(notebook_name))
 
-    install_nbextension(jupyter=args.jexe)
+    if not args.disable_autorun:
+        install_nbextension(jupyter=args.jexe)
 
     try:
         subprocess.check_call(cm.split())
@@ -184,7 +186,8 @@ def main(notebook_dict=notebook_dict):
         if args.clean_cache and create_new_nb:
             print("deleting {}".format(notebook_name))
             os.remove(notebook_name)
-        disable_extension(jupyter=args.jexe)
+        if not args.disable_autorun:
+            disable_extension(jupyter=args.jexe)
 
 if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ if __name__ == '__main__':
         packages=["nglview", "nglview.datafiles",
                   "nglview.js", "nglview.scripts",
                   "nglview.theme"],
-        install_requires=["jupyter", "traitlets>=4.2.1", "ipywidgets<5.0"],
+        install_requires=["jupyter", "traitlets>=4.2.1", "ipywidgets<5.0", "notebook<4.2"],
         tests_require=["pytest"],
         # test_suite="nose.collector",
         extras_require={


### PR DESCRIPTION
man, I am really frustrated with Jupyter project now. Why not just increase the notebook version to 5.0 to match to `ipywidgets`? The API is broken. Honestly, who can be patient to read the change logs of a bunch of projects??

Why not just `python setup.py install` and just work???