### PR TITLE
add slider to resize notebook

### DIFF
--- a/nglview/js/widget_ngl.js
+++ b/nglview/js/widget_ngl.js
@@ -448,14 +448,14 @@ define( [
         },
 
         setDialog: function(){
-            var nb_container = Jupyter.notebook.container;
+            var $nb_container = Jupyter.notebook.container;
             var that = this;
             dialog  = this.$container.dialog({
                 title: "NGLView",
                 draggable: true,
                 resizable: true,
                 modal: false,
-                width: nb_container.offset().left,
+                width: $nb_container.offset().left,
                 height:"auto",
                 position: {my: 'left', at: 'left', of: window},
                 show: { effect: "blind", duration: 150 },
@@ -472,6 +472,15 @@ define( [
             dialog.prev('.ui-dialog-titlebar')
                   .css({'background': 'transparent',
                         'border': 'none'});
+        },
+
+        resizeNotebook(width){
+            var $nb_container = Jupyter.notebook.container;
+            $nb_container.width(width);
+
+            if (this.$container.dialog){
+                this.$container.dialog({width: $nb_container.offset().left});
+            }
         },
 
         parametersChanged: function(){

--- a/nglview/player.py
+++ b/nglview/player.py
@@ -505,3 +505,13 @@ class TrajectoryPlayer(DOMWidget):
             checkbox_antialias,
             checkbox_trim,
             checkbox_transparent])
+
+    def _make_resize_notebook_slider(self):
+        resize_notebook_slider = IntSlider(min=300, max=2000, description='resize notebook')
+        def on_resize_notebook(change):
+            width = change['new']
+            self._view._remote_call('resizeNotebook',
+                    target='Widget',
+                    args=[width,])
+        resize_notebook_slider.observe(on_resize_notebook, names='value')
+        return resize_notebook_slider


### PR DESCRIPTION
the main aim is when resizing notebook container, the Widget is also resized to avoid overlapping.

![notebook](https://cloud.githubusercontent.com/assets/4451957/16709829/3141226c-45ea-11e6-8ceb-43ec92188d2c.png)


```python
view.player._make_resize_notebook_slider()
```