### PR TITLE
ADD: _refresh_render for a single frame trajectory

### DIFF
--- a/nglview/__init__.py
+++ b/nglview/__init__.py
@@ -773,6 +773,18 @@ class NGLWidget(DOMWidget):
         if change['new']:
             [callback(self) for callback in self._ngl_displayed_callbacks]
 
+    def _refresh_render(self):
+        """useful when you update coordinates for a single structure.
+
+        Notes
+        -----
+        If you are visualizing a trajectory with more than 1 frame, you can use the
+        player slider to trigger the refreshing.
+        """
+        current_frame = self.frame 
+        self.frame = int(1E6)
+        self.frame = current_frame
+
     def sync_view(self):
         """call this if you want to sync multiple views of a single viewer
 

--- a/nglview/tests/notebooks/test_refresh_render.ipynb
+++ b/nglview/tests/notebooks/test_refresh_render.ipynb
@@ -1,0 +1,183 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import nglview as nv\n",
+    "from nglview.utils import get_colors_from_b64\n",
+    "import pytraj as pt\n",
+    "\n",
+    "ala3 = pt.datafiles.load_ala3()\n",
+    "\n",
+    "view = nv.show_pytraj(ala3)\n",
+    "view.add_licorice()\n",
+    "view"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "view.render_image()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "c0 = get_colors_from_b64(view._image_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "pytraj.TrajectoryIterator, 1 frames: \n",
+       "Size: 0.000001 (GB)\n",
+       "<Topology: 34 atoms, 3 residues, 1 mols, non-PBC>\n",
+       "           "
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ala3.rotate('x 60')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "view.render_image()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "c1 = get_colors_from_b64(view._image_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# same render if not refreshing\n",
+    "assert c0 == c1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "view._refresh_render()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "view.render_image()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "c2 = view._image_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "assert c2 != c1"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [default]",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
+  },
+  "widgets": {
+   "state": {
+    "304c30e6e7ad42ca9c8638d9954a9ceb": {
+     "views": [
+      {
+       "cell_index": 0
+      }
+     ]
+    }
+   },
+   "version": "1.2.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
For a single frame trajectory, if user update the coordinates, there's no way to signal this change to `nglview`. So just adding `_refrersh_render`.

For long trajectory, this is not necessary since the coordinates will be updated when the player slider changes.