### PR TITLE
fix for _exportImage

### DIFF
--- a/js/src/widget_ngl.js
+++ b/js/src/widget_ngl.js
@@ -712,7 +712,7 @@ var NGLView = widgets.DOMWidgetView.extend({
         this.stage.setParameters(parameters);
 
         // do not set _full_stage_parameters here
-        // or parameters will be never updated (not sure why) 
+        // or parameters will be never updated (not sure why)
         // use observe in python side
         var updated_params = this.stage.getParameters();
         this.send({
@@ -739,8 +739,8 @@ var NGLView = widgets.DOMWidgetView.extend({
             var reader = new FileReader();
             var arr_str;
             reader.onload = function() {
-                arr_str = reader.result.replace("data:image/png;base64,", "");
-                this.model.set("_image_data", arr_str);
+                //arr_str = reader.result.replace("data:image/png;base64,", "");
+                this.model.set("_image_data", reader.result);
                 this.touch();
             }.bind(this);
             reader.readAsDataURL(blob);
@@ -765,7 +765,7 @@ var NGLView = widgets.DOMWidgetView.extend({
     _handle_loading_file_finished: function() {
         this.send({'type': 'async_message', 'data': 'ok'});
     },
-    
+
     _handle_stage_loadFile: function(msg){
             // args = [{'type': ..., 'data': ...}]
          var args0 = msg.args[0];


### PR DESCRIPTION
I was trying without success to fetch the image of a view using 

    view._display_image()

(I think this is related to #599 ) 
In fact, `view._image_data` turned out to be empty. 

Just removing the text replacement in `_exportImage()` works for me (see screenshot)
I'm not sure if this is a proper fix though...

![screen shot 2017-06-20 at 17 35 19](https://user-images.githubusercontent.com/466063/27341886-debd7e2c-55de-11e7-85c7-e5d70cf8ba00.png)



