### PR TITLE
ENH: nightwatch (again)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,9 @@ python ./devtools/make_test_js.py
 - run
 
 ```bash
+# install chromedriver: https://chromedriver.storage.googleapis.com/index.html?path=2.30/
+# (tested on MacOS 10.12.5)
+# after download, unzip and copy chromedriver to /use/local/bin or anywhere in your PATH
 source devtools/travis-ci/clone_nbtest.sh # only once
 jupyter notebook --port=8889 &
 # npm install -g nightwatch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,9 @@ python ./devtools/make_test_js.py
 # (tested on MacOS 10.12.5)
 # after download, unzip and copy chromedriver to /use/local/bin or anywhere in your PATH
 source devtools/travis-ci/clone_nbtest.sh # only once
+# You might want to update
+# c.NotebookApp.token = '' in $HOME/.jupyter/jupyter_notebook_config.py
+# to avoid entering token or password.
 jupyter notebook --port=8889 &
 # npm install -g nightwatch
 nightwatch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,23 +102,49 @@ Test notebook
 
 - [edit to add more notebooks] and update notebook files
 ```bash
-python ./devtools/make_test_js.py
+python ./devtools/make_test_js.py --api
 ```
 
-- run
+- install chromedriver: https://chromedriver.storage.googleapis.com/index.html?path=2.30/
 
-```bash
-# install chromedriver: https://chromedriver.storage.googleapis.com/index.html?path=2.30/
-# (tested on MacOS 10.12.5)
-# after download, unzip and copy chromedriver to /use/local/bin or anywhere in your PATH
+    Download, unzip and copy chromedriver to /use/local/bin or anywhere in your PATH
+    (tested on MacOS 10.12.5)
+
+- install nightwatch
+
+```
+npm install -g nightwatch
+```
+
+- install notebook runner
+
+```
 source devtools/travis-ci/clone_nbtest.sh # only once
-# You might want to update
-# c.NotebookApp.token = '' in $HOME/.jupyter/jupyter_notebook_config.py
-# to avoid entering token or password.
+```
+
+- (may be): 
+
+To avoid entering notebook token or password, you might want to update
+
+    c.NotebookApp.token = '' in $HOME/.jupyter/jupyter_notebook_config.py
+
+- Run notebook server
+
+```
 jupyter notebook --port=8889 &
-# npm install -g nightwatch
+```
+
+- Run all tests
+```bash
 nightwatch
 ```
+
+- Run a single test
+```bash
+# nightwatch /path/to/your/file.js
+nightwatch nglview/tests/js/render_image.js
+```
+
 
 More stuff
 ==========

--- a/devtools/make_test_js.py
+++ b/devtools/make_test_js.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import os
 import subprocess
 from glob import glob
 from random import shuffle
@@ -78,3 +79,11 @@ if __name__ == '__main__':
     fn = 'nglview/tests/js/test.js'
     with open(fn, 'w') as fh:
         fh.write(head + all_notebooks + tail)
+
+    for nb_abspath, n_cells in notebooks_with_cell_lengths:
+        basename = os.path.basename(nb_abspath)
+        js_fn = os.path.join('nglview/tests/js',
+                os.path.splitext(basename)[0] + '.js')
+        with open(js_fn, 'w') as fh:
+            body = body_template % (nb_abspath, nb_abspath, n_cells)
+            fh.write(head + body + tail)

--- a/nglview/tests/js/test.js
+++ b/nglview/tests/js/test.js
@@ -2,44 +2,8 @@
 module.exports = {
 
 
-    "nglview/tests/notebooks/api/binary_vs_base64.ipynb": function (browser) {
-        browser.openNotebook("nglview/tests/notebooks/api/binary_vs_base64.ipynb");
-        browser.restartKernel(2000);
-        for ( var i = 0; i < 34; i++) {
-           browser.executeCell(i)
-                  .pause(3000)
-                  .cellHasError(i);
-        }
-        browser.end();
-    },
-
-
     "nglview/tests/notebooks/api/render_image.ipynb": function (browser) {
         browser.openNotebook("nglview/tests/notebooks/api/render_image.ipynb");
-        browser.restartKernel(2000);
-        for ( var i = 0; i < 12; i++) {
-           browser.executeCell(i)
-                  .pause(3000)
-                  .cellHasError(i);
-        }
-        browser.end();
-    },
-
-
-    "nglview/tests/notebooks/api/test_2_widget_views.ipynb": function (browser) {
-        browser.openNotebook("nglview/tests/notebooks/api/test_2_widget_views.ipynb");
-        browser.restartKernel(2000);
-        for ( var i = 0; i < 8; i++) {
-           browser.executeCell(i)
-                  .pause(3000)
-                  .cellHasError(i);
-        }
-        browser.end();
-    },
-
-
-    "nglview/tests/notebooks/api/test_2_widget_views_fist_time_loaded.ipynb": function (browser) {
-        browser.openNotebook("nglview/tests/notebooks/api/test_2_widget_views_fist_time_loaded.ipynb");
         browser.restartKernel(2000);
         for ( var i = 0; i < 12; i++) {
            browser.executeCell(i)
@@ -53,7 +17,7 @@ module.exports = {
     "nglview/tests/notebooks/api/test_add_shape.ipynb": function (browser) {
         browser.openNotebook("nglview/tests/notebooks/api/test_add_shape.ipynb");
         browser.restartKernel(2000);
-        for ( var i = 0; i < 10; i++) {
+        for ( var i = 0; i < 6; i++) {
            browser.executeCell(i)
                   .pause(3000)
                   .cellHasError(i);
@@ -65,7 +29,7 @@ module.exports = {
     "nglview/tests/notebooks/api/test_add_structure_then_trajectory.ipynb": function (browser) {
         browser.openNotebook("nglview/tests/notebooks/api/test_add_structure_then_trajectory.ipynb");
         browser.restartKernel(2000);
-        for ( var i = 0; i < 8; i++) {
+        for ( var i = 0; i < 6; i++) {
            browser.executeCell(i)
                   .pause(3000)
                   .cellHasError(i);
@@ -74,22 +38,10 @@ module.exports = {
     },
 
 
-    "nglview/tests/notebooks/api/test_auto_detect_pytraj_mdtraj_mdanalysis_parmed.ipynb": function (browser) {
-        browser.openNotebook("nglview/tests/notebooks/api/test_auto_detect_pytraj_mdtraj_mdanalysis_parmed.ipynb");
+    "nglview/tests/notebooks/api/test_callbacks.ipynb": function (browser) {
+        browser.openNotebook("nglview/tests/notebooks/api/test_callbacks.ipynb");
         browser.restartKernel(2000);
-        for ( var i = 0; i < 82; i++) {
-           browser.executeCell(i)
-                  .pause(3000)
-                  .cellHasError(i);
-        }
-        browser.end();
-    },
-
-
-    "nglview/tests/notebooks/api/test_automatically_added_attributes_0.ipynb": function (browser) {
-        browser.openNotebook("nglview/tests/notebooks/api/test_automatically_added_attributes_0.ipynb");
-        browser.restartKernel(2000);
-        for ( var i = 0; i < 32; i++) {
+        for ( var i = 0; i < 22; i++) {
            browser.executeCell(i)
                   .pause(3000)
                   .cellHasError(i);
@@ -122,8 +74,8 @@ module.exports = {
     },
 
 
-    "nglview/tests/notebooks/api/test_detach.ipynb": function (browser) {
-        browser.openNotebook("nglview/tests/notebooks/api/test_detach.ipynb");
+    "nglview/tests/notebooks/api/test_movie_making.ipynb": function (browser) {
+        browser.openNotebook("nglview/tests/notebooks/api/test_movie_making.ipynb");
         browser.restartKernel(2000);
         for ( var i = 0; i < 8; i++) {
            browser.executeCell(i)

--- a/nightwatch.json
+++ b/nightwatch.json
@@ -9,7 +9,7 @@
   "selenium" : {
     "start_process" : true,
     "start_session": true,
-    "server_path" : "nbtests/selenium-server-standalone-2.53.0.jar",
+    "server_path" : "nbtests/selenium-server-standalone-3.4.0.jar",
     "log_path" : "",
     "host" : "127.0.0.1",
     "port" : 4444,


### PR DESCRIPTION
Damn, finally I can make notebook test with `chromedriver` works again.
Very tricky (need to use correct `chromedriver` version (in this case, v2.30)). 

Example
---------
```
$ nightwatch 
Starting selenium server... started - PID:  17011

[Render Image] Test Suite
=============================

Running:  nglview/tests/notebooks/api/render_image.ipynb
url http://localhost:8889/notebooks/nglview/tests/notebooks/api/render_image.ipynb
 ✔ Passed [ok]: Check that python has no error
 ✔ Passed [ok]: Check that python has no error
 ✔ Passed [ok]: Check that python has no error
 ✔ Passed [ok]: Check that python has no error
 ✔ Passed [ok]: Check that python has no error
 ✔ Passed [ok]: Check that python has no error
```
