### PR TITLE
View a Biopython object

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,12 +146,13 @@ the file-system, [RCSB PDB](http:www.rcsb.org), [simpletraj](https://github.com/
 | `show_simpletraj(struc_path, traj_path)` | Shows structure & trajectory loaded with `simpletraj` |
 | `show_mdtraj(traj)`                      | Shows `MDTraj` trajectory `traj`                      |
 | `show_pytraj(traj)`                      | Shows `PyTraj` trajectory `traj`                      |
-| `show_parmed(structure)`                 | Shows `ParmEd` structure
+| `show_parmed(structure)`                 | Shows `ParmEd` structure                              |
 | `show_mdanalysis(univ)`                  | Shows `MDAnalysis` Universe or AtomGroup `univ`       |
 | `show_rdkit(mol)`                        | Shows `rdkit` rdkit.Chem.rdchem.Mol                   |
 | `show_ase(atoms)`                        | Shows `ase` Atoms                                     |
 | `show_asetraj(traj)`                     | Shows `ase` trajectory `traj`                         |
 | `show_htmd(mol)`                         | Shows `HTMD` Molecules                                |
+| `show_biopython(mol)`                    | Shows `Biopython` structural entities                 |
 
 
 API

--- a/nglview/adaptor.py
+++ b/nglview/adaptor.py
@@ -131,7 +131,10 @@ class BiopythonStructure(Structure):
 
     def get_structure_string(self):
         from Bio.PDB import PDBIO
-        from StringIO import StringIO
+        try:
+            from StringIO import StringIO
+        except ImportError:
+            from io import StringIO
         io_pdb = PDBIO()
         io_pdb.set_structure(self._entity)
         io_str = StringIO()

--- a/nglview/adaptor.py
+++ b/nglview/adaptor.py
@@ -21,9 +21,10 @@ from . import config
 
 __all__ = [
     'FileStructure', 'TextStructure', 'RdkitStructure', 'PdbIdStructure',
-    'ASEStructure', 'SimpletrajTrajectory', 'MDTrajTrajectory',
-    'PyTrajTrajectory', 'ParmEdTrajectory', 'MDAnalysisTrajectory',
-    'HTMDTrajectory', 'ASETrajectory', 'register_backend'
+    'ASEStructure', 'BiopythonStructure', 'SimpletrajTrajectory',
+    'MDTrajTrajectory', 'PyTrajTrajectory', 'ParmEdTrajectory',
+    'MDAnalysisTrajectory', 'HTMDTrajectory', 'ASETrajectory',
+    'register_backend',
 ]
 
 
@@ -118,6 +119,24 @@ class ASEStructure(Structure):
         with tempfolder():
             self._ase_atoms.write('tmp.pdb')
             return open('tmp.pdb').read()
+
+
+class BiopythonStructure(Structure):
+    def __init__(self, entity, ext='pdb', params={}):
+        super(BiopythonStructure, self).__init__()
+        self.path = ''
+        self.ext = ext
+        self.params = params
+        self._entity = entity
+
+    def get_structure_string(self):
+        from Bio.PDB import PDBIO
+        from StringIO import StringIO
+        io_pdb = PDBIO()
+        io_pdb.set_structure(self._entity)
+        io_str = StringIO()
+        io_pdb.save(io_str)
+        return io_str.getvalue()
 
 
 @register_backend('simpletraj')

--- a/nglview/show.py
+++ b/nglview/show.py
@@ -9,9 +9,9 @@ from .widget import NGLWidget
 from . import datafiles
 
 from .adaptor import (FileStructure, TextStructure, PdbIdStructure,
-                      ASEStructure, MDTrajTrajectory, PyTrajTrajectory,
-                      ParmEdTrajectory, MDAnalysisTrajectory, HTMDTrajectory,
-                      ASETrajectory, SchrodingerStructure)
+                      ASEStructure, BiopythonStructure, MDTrajTrajectory,
+                      PyTrajTrajectory, ParmEdTrajectory, MDAnalysisTrajectory,
+                      HTMDTrajectory, ASETrajectory, SchrodingerStructure)
 
 __all__ = [
     'demo',
@@ -282,7 +282,7 @@ def show_schrodinger_structure(mol, **kwargs):
     return NGLWidget(structure_trajectory, **kwargs)
 
 
-def show_biopython(mol, **kwargs):
+def show_biopython(entity, **kwargs):
     '''Show NGL widget with Biopython structural entity.
 
     Takes a Structure, Model, Chain, Residue or Atom
@@ -297,14 +297,8 @@ def show_biopython(mol, **kwargs):
     ... w = nv.show_biopython(structure[0]["A"])
     ... w
     '''
-    from Bio.PDB import PDBIO
-    from StringIO import StringIO
-    io_pdb = PDBIO()
-    io_pdb.set_structure(mol)
-    io_str = StringIO()
-    io_pdb.save(io_str)
-    prot_str = io_str.getvalue()
-    return show_text(prot_str, **kwargs)
+    entity = BiopythonStructure(entity)
+    return show_text(entity.get_structure_string(), **kwargs)
 
 
 def demo(*args, **kwargs):

--- a/nglview/show.py
+++ b/nglview/show.py
@@ -5,10 +5,6 @@ try:
 except ImportError:
     from io import StringIO
 
-from StringIO import StringIO as StringIOOld
-
-from Bio.PDB import PDBIO
-
 from .widget import NGLWidget
 from . import datafiles
 
@@ -301,9 +297,11 @@ def show_biopython(mol, **kwargs):
     ... w = nv.show_biopython(structure[0]["A"])
     ... w
     '''
+    from Bio.PDB import PDBIO
+    from StringIO import StringIO
     io_pdb = PDBIO()
     io_pdb.set_structure(mol)
-    io_str = StringIOOld()
+    io_str = StringIO()
     io_pdb.save(io_str)
     prot_str = io_str.getvalue()
     return show_text(prot_str, **kwargs)

--- a/nglview/show.py
+++ b/nglview/show.py
@@ -5,6 +5,10 @@ try:
 except ImportError:
     from io import StringIO
 
+from StringIO import StringIO as StringIOOld
+
+from Bio.PDB import PDBIO
+
 from .widget import NGLWidget
 from . import datafiles
 
@@ -29,6 +33,7 @@ __all__ = [
     'show_structure_file',
     'show_htmd',
     'show_schrodinger_structure',
+    'show_biopython',
 ]
 
 
@@ -279,6 +284,29 @@ def show_schrodinger_structure(mol, **kwargs):
     '''
     structure_trajectory = SchrodingerStructure(mol)
     return NGLWidget(structure_trajectory, **kwargs)
+
+
+def show_biopython(mol, **kwargs):
+    '''Show NGL widget with Biopython structural entity.
+
+    Takes a Structure, Model, Chain, Residue or Atom
+    from Bio.PDB as its data input.
+
+    Examples
+    --------
+    >>> import nglview as nv # doctest: +SKIP
+    ... from Bio.PDB import PDBParser
+    ... parser = PDBParser()
+    ... structure = parser.get_structure("protein", "protein.pdb")
+    ... w = nv.show_biopython(structure[0]["A"])
+    ... w
+    '''
+    io_pdb = PDBIO()
+    io_pdb.set_structure(mol)
+    io_str = StringIOOld()
+    io_pdb.save(io_str)
+    prot_str = io_str.getvalue()
+    return show_text(prot_str, **kwargs)
 
 
 def demo(*args, **kwargs):

--- a/nglview/show.py
+++ b/nglview/show.py
@@ -298,7 +298,8 @@ def show_biopython(entity, **kwargs):
     ... w
     '''
     entity = BiopythonStructure(entity)
-    return show_text(entity.get_structure_string(), **kwargs)
+    structure = TextStructure(entity.get_structure_string())
+    return NGLWidget(structure, **kwargs)
 
 
 def demo(*args, **kwargs):

--- a/nglview/show.py
+++ b/nglview/show.py
@@ -298,8 +298,7 @@ def show_biopython(entity, **kwargs):
     ... w
     '''
     entity = BiopythonStructure(entity)
-    structure = TextStructure(entity.get_structure_string())
-    return NGLWidget(structure, **kwargs)
+    return NGLWidget(entity, **kwargs)
 
 
 def demo(*args, **kwargs):

--- a/nglview/tests/test_widget.py
+++ b/nglview/tests/test_widget.py
@@ -79,6 +79,12 @@ try:
 except ImportError:
     has_ase = False
 
+try:
+    import Bio.PDB
+    has_bio = True
+except ImportError:
+    has_bio = False
+
 
 # local
 from utils import get_fn, repr_dict as REPR_DICT
@@ -470,6 +476,14 @@ def test_show_ase():
     dimer = Atoms([Atom('X', (0, 0, 0)), Atom('X', (0, 0, 1))])
     dimer.set_positions([(1, 2, 3), (4, 5, 6.2)])
     nv.show_ase(dimer)
+
+
+@unittest.skipUnless(has_bio, 'skip if not having biopython')
+def test_show_biopython():
+    from Bio.PDB import PDBParser
+    parser = PDBParser()
+    structure = parser.get_structure('protein', nv.datafiles.PDB)
+    nv.show_biopython(structure)
 
 
 @unittest.skipUnless(has_simpletraj, 'skip if not having simpletraj')

--- a/pip-requirements-test.txt
+++ b/pip-requirements-test.txt
@@ -12,6 +12,7 @@ numpy
 ase
 parmed
 pytraj
+biopython
 
 # movie making
 matplotlib==2.0.2


### PR DESCRIPTION
I thought a cool idea would be that you could view a Biopython structural object in Jupyter using nglview.

I have put together some code that lets you do the following:

```python
import nglview as nv
from Bio.PDB import PDBParser

# Read in a PDB file with Biopython
parser = PDBParser()
structure = parser.get_structure("1AKE", "1AKE.pdb")

# Show a structure
view1 = nv.show_biopython(structure)
view1

# Show a chain
view2 = nv.show_biopython(structure[0]["A"])
view2

# Show a residue
view3 = nv.show_biopython(structure[0]["A"][50])
view3
```

It writes the Biopython object out to a string and reads that back in with `show_text`.

Let me know what you think. Current problems are that you need the old `StringIO` method because Biopython writes strings not unicode, and that the Bio.PDB.PDBIO import is required.

CC @sbliven.

Screengrab here:
<img width="738" alt="screen shot 2017-07-20 at 17 00 33" src="https://user-images.githubusercontent.com/6620652/28424208-51d55452-6d6d-11e7-9716-233d5b85c074.png">