### PR TITLE
FIx for show_pdbid and Python3

### DIFF
--- a/nglview/adaptor.py
+++ b/nglview/adaptor.py
@@ -87,7 +87,7 @@ class PdbIdStructure(Structure):
 
     def get_structure_string(self):
         url = "http://www.rcsb.org/pdb/files/" + self.pdbid + ".cif"
-        return urlopen(url).read()
+        return urlopen(url).read().decode('utf-8')
 
 
 class ASEStructure(Structure):


### PR DESCRIPTION
My simple test notebook with show_pdbid("3pqr") does not work for Python 3.7.1 in anaconda-2018.12
Nothing gets displayed.  FIxed it by decoding the bytestring returned from urlopen()