### PR TITLE
ADD (sandbox code) for trajectory smoothing

### DIFF
--- a/nglview/sandbox/interpolate.py
+++ b/nglview/sandbox/interpolate.py
@@ -1,0 +1,49 @@
+"""This module is meant for playground.
+"""
+
+import numpy as np
+
+
+def smooth(coords_3d, method='filtfilt', inplace=True, atom_indices=None, **kwargs):
+    """
+    Parameters
+    ----------
+    coords_3d : 3d numpy's array
+    method : str, {'filtfilt', 'savgol_filter'}
+    atom_indices : None or 1d integer array-like
+        If None, using all atoms.
+    kwargs : Additional arguments for corresponding method.
+
+    Examples
+    --------
+    >>> import nglview as nv
+    >>> from nglview.sandbox.interpolate import smooth
+    >>> import pytraj as pt
+    >>> traj = pt.datafiles.load_tz2()[:]
+    >>> traj.xyz = smooth(traj.xyz)
+    >>> view = nv.show_pytraj(traj)
+    >>> view.clear()
+    >>> view.add_licorice('protein')
+    >>> view
+    """
+    from scipy import signal
+    if inplace:
+        xyz = coords_3d
+    else:
+        xyz = coords_3d.copy()
+    n_atoms = coords_3d[0].shape[0]
+    xyz0 = xyz[0].copy()
+    atom_indices = atom_indices or range(n_atoms)
+    for idx in atom_indices:
+        for j in range(3):
+            xyz_idx_j = xyz[:, idx, j]
+            if method == 'filtfilt':
+                b, a = signal.butter(3, 0.1)
+                smooth_data = signal.filtfilt(b, a, xyz_idx_j, **kwargs)
+            elif method == 'savgol_filter':
+                smooth_data = signal.savgol_filter(xyz_idx_j, **kwargs)
+            else:
+                raise ValueError(f"%s method is not supported" % method)
+            xyz[:, idx, j] = smooth_data
+    xyz[0] = xyz0 # to correctly render 1st frame.
+    return xyz


### PR DESCRIPTION
Related case: #740 

![smooth](https://user-images.githubusercontent.com/4451957/57004893-edcbb300-6ba0-11e9-82a2-50dfc6368426.gif)

Code example:
```python
import nglview as nv
from nglview.sandbox.interpolate import smooth
import pytraj as pt

traj = pt.datafiles.load_trpcage()[:]
traj.superpose()
traj_smoothed = traj.copy()
traj_smoothed.xyz = smooth(traj_smoothed.xyz, method='savgol_filter', window_length=11, polyorder=3)
traj.translate('x 20')
traj_smoothed3 = traj.copy()
traj_smoothed3.xyz = smooth(traj_smoothed3.xyz)
traj.translate('x 20')

kwargs = {'default_representation': False}
view = nv.NGLWidget()

c0 = view.add_trajectory(nv.PyTrajTrajectory(traj), **kwargs)
c0.add_ball_and_stick('backbone or TRP')

c1 = view.add_trajectory(nv.PyTrajTrajectory(traj_smoothed), **kwargs)
c1.add_ball_and_stick('backbone or TRP')

c3 = view.add_trajectory(nv.PyTrajTrajectory(traj_smoothed3), **kwargs)
c3.add_ball_and_stick('backbone or TRP')

view.control.orient([28.27254663341445,
 0,
 3.409084934332838,
 0,
 0,
 28.477337537559414,
 0,
 0,
 -3.409084934332838,
 0,
 28.27254663341445,
 0,
 -21.208489890749334,
 -0.23829763922190267,
 0,
 1])

view.camera = 'orthographic'
view
```