### PR TITLE
ADD sandbox code for jupyter-lab display

### DIFF
--- a/nglview/sandbox/lab.py
+++ b/nglview/sandbox/lab.py
@@ -1,0 +1,7 @@
+from IPython.display import display
+
+
+def lab_display(view):
+    from sidecar import Sidecar
+    with Sidecar(title='nglview'):
+        display(view)


### PR DESCRIPTION
Require: `sidecar`

Example
<img width="1263" alt="Screen Shot 2019-05-16 at 1 19 46 AM" src="https://user-images.githubusercontent.com/4451957/57828255-e697ce00-7778-11e9-9abc-d62d8a7d01a0.png">


