### PR TITLE
Render image enhancement: we don't need `_display_image` anymore.

### DIFF
--- a/nglview/widget.py
+++ b/nglview/widget.py
@@ -953,19 +953,20 @@ class NGLWidget(DOMWidget):
         self._remote_call('_exportImage', target='Widget', kwargs=params)
 
         old_data = self._image_data[:]
-        out_widget = Output()
+        iw = Image()
+        iw.width = '99%' # avoid ugly scroll bar on notebook.
+
         def _display():
             from IPython.display import display, Image
             t0 = time.time()
             while old_data == self._image_data:
                 time.sleep(0.01)
-            with out_widget:
-                display(Image(base64.b64decode(self._image_data)))
+            iw.value = base64.b64decode(self._image_data)
 
         thread = threading.Thread(target=_display)
         thread.daemon = True
         thread.start()
-        return out_widget
+        return iw
 
     def download_image(self,
                        filename='screenshot.png',

--- a/nglview/widget.py
+++ b/nglview/widget.py
@@ -5,7 +5,7 @@ import uuid
 import json
 import numpy as np
 from IPython.display import display
-from ipywidgets import Box, DOMWidget
+from ipywidgets import Box, DOMWidget, Output
 try:
     # ipywidgets >= 7.4
     from ipywidgets import Image
@@ -951,6 +951,21 @@ class NGLWidget(DOMWidget):
             trim=trim,
             transparent=transparent)
         self._remote_call('_exportImage', target='Widget', kwargs=params)
+
+        old_data = self._image_data[:]
+        out_widget = Output()
+        def _display():
+            from IPython.display import display, Image
+            t0 = time.time()
+            while old_data == self._image_data:
+                time.sleep(0.01)
+            with out_widget:
+                display(Image(base64.b64decode(self._image_data)))
+
+        thread = threading.Thread(target=_display)
+        thread.daemon = True
+        thread.start()
+        return out_widget
 
     def download_image(self,
                        filename='screenshot.png',


### PR DESCRIPTION
wow, finally I can make this work. 

In our current code (before this change), user needs to execute codes in two cells to make the display work
```
# cell 1
view.render_image()

# cell 2
view._display_image()
```

This change remove the drawback. Here is an example:
<img width="1012" alt="Screen Shot 2019-05-21 at 12 44 36 AM" src="https://user-images.githubusercontent.com/4451957/58068981-a1e9a980-7b61-11e9-9d87-d31bdf77822f.png">

Or even better, we can execute multiple `render_image` calls in a single cell, with the help from `time.sleep` and `threading`.

<img width="388" alt="Screen Shot 2019-05-21 at 12 38 13 AM" src="https://user-images.githubusercontent.com/4451957/58069013-c0e83b80-7b61-11e9-91f1-efd02c4e69a4.png">
