### PR TITLE
Use view.layout.{width,height} for _set_size

### DIFF
--- a/nglview/tests/test_widget.py
+++ b/nglview/tests/test_widget.py
@@ -135,6 +135,10 @@ def test_API_promise_to_have():
 
     view = nv.demo()
 
+    # trigger _set_size
+    view.layout.width = '100px'
+    view.layout.height = '500px'
+
     # Structure
     structure = nv.Structure()
     structure.get_structure_string

--- a/nglview/widget.py
+++ b/nglview/widget.py
@@ -213,6 +213,19 @@ class NGLWidget(DOMWidget):
         self.player = TrajectoryPlayer(self)
         self._already_constructed = True
 
+        # Updating only self.layout.{width, height} don't handle
+        # resizing NGL widget properly.
+        self._sync_with_layout()
+
+    def _sync_with_layout(self):
+        def on_change_layout(change):
+            new = change['new']
+            if change['name'] == 'width':
+                self._set_size(new, '')
+            elif change['name'] == 'height':
+                self._set_size('', new)
+        self.layout.observe(on_change_layout, ['width', 'height']) 
+
     def _set_serialization(self, frame_range=None):
         self._ngl_serialize = True
         self._ngl_msg_archive = [f._ngl_msg


### PR DESCRIPTION
# Before this change:
<img width="1196" alt="Screen Shot 2019-06-03 at 10 59 55 PM" src="https://user-images.githubusercontent.com/4451957/58848149-754e8b00-8653-11e9-8da5-357f94e6ff9b.png">

# This change
<img width="1181" alt="Screen Shot 2019-06-03 at 10 58 58 PM" src="https://user-images.githubusercontent.com/4451957/58848157-7d0e2f80-8653-11e9-82f0-a426e7e932e8.png">

We don't need to call the private method `_set_size` anymore.