### PR TITLE
ADD sandbox code for fullscreen_mode + REMOVE: spin from player (rarely used?)

### DIFF
--- a/nglview/player.py
+++ b/nglview/player.py
@@ -30,11 +30,6 @@ class TrajectoryPlayer(HasTraits):
     iparams = Dict()
     _interpolation_t = Float()
     _iterpolation_type = CaselessStrEnum(['linear', 'spline'])
-    spin = Bool(False)
-    _spin_x = Int(1)
-    _spin_y = Int(0)
-    _spin_z = Int(0)
-    _spin_speed = Float(0.005)
     camera = CaselessStrEnum(
         ['perspective', 'orthographic'],
         default_value='perspective')
@@ -144,44 +139,6 @@ class TrajectoryPlayer(HasTraits):
     @observe('_interpolation_t')
     def _interpolation_t_changed(self, change):
         self.iparams['t'] = change['new']
-
-    @observe('spin')
-    def _on_spin_changed(self, change):
-        self.spin = change['new']
-        if self.spin:
-            self._view._set_spin([self._spin_x, self._spin_y, self._spin_z],
-                                 self._spin_speed)
-        else:
-            # stop
-            self._view._set_spin(None, None)
-
-    @observe('_spin_x')
-    def _on_spin_x_changed(self, change):
-        self._spin_x = change['new']
-        if self.spin:
-            self._view._set_spin([self._spin_x, self._spin_y, self._spin_z],
-                                 self._spin_speed)
-
-    @observe('_spin_y')
-    def _on_spin_y_changed(self, change):
-        self._spin_y = change['new']
-        if self.spin:
-            self._view._set_spin([self._spin_x, self._spin_y, self._spin_z],
-                                 self._spin_speed)
-
-    @observe('_spin_z')
-    def _on_spin_z_changed(self, change):
-        self._spin_z = change['new']
-        if self.spin:
-            self._view._set_spin([self._spin_x, self._spin_y, self._spin_z],
-                                 self._spin_speed)
-
-    @observe('_spin_speed')
-    def _on_spin_speed_changed(self, change):
-        self._spin_speed = change['new']
-        if self.spin:
-            self._view._set_spin([self._spin_x, self._spin_y, self._spin_z],
-                                 self._spin_speed)
 
     def _display(self):
         if self.widget_tab:
@@ -699,34 +656,6 @@ class TrajectoryPlayer(HasTraits):
         self.widget_repr_choices = repr_choices
         return self.widget_repr_choices
 
-    def _make_spin_box(self):
-        checkbox_spin = Checkbox(self.spin, description='spin')
-        spin_x_slide = IntSlider(
-            self._spin_x, min=-1, max=1, description='spin_x')
-        spin_y_slide = IntSlider(
-            self._spin_y, min=-1, max=1, description='spin_y')
-        spin_z_slide = IntSlider(
-            self._spin_z, min=-1, max=1, description='spin_z')
-        spin_speed_slide = FloatSlider(
-            self._spin_speed,
-            min=0,
-            max=0.2,
-            step=0.001,
-            description='spin speed')
-        # spin
-        link((checkbox_spin, 'value'), (self, 'spin'))
-        link((spin_x_slide, 'value'), (self, '_spin_x'))
-        link((spin_y_slide, 'value'), (self, '_spin_y'))
-        link((spin_z_slide, 'value'), (self, '_spin_z'))
-        link((spin_speed_slide, 'value'), (self, '_spin_speed'))
-
-        spin_box = VBox([
-            checkbox_spin, spin_x_slide, spin_y_slide, spin_z_slide,
-            spin_speed_slide
-        ])
-        spin_box = _relayout_master(spin_box, width='75%')
-        return spin_box
-
     def _make_widget_picked(self):
         self.widget_picked = self._make_text_picked()
         picked_box = HBox([
@@ -742,7 +671,6 @@ class TrajectoryPlayer(HasTraits):
     def _make_extra_box(self):
         if self.widget_extra is None:
             extra_list = [
-                          (self._make_spin_box, 'Spin'),
                           (self._make_widget_picked, 'Picked'),
                           (self._make_repr_playground, 'Quick'),
                           (self._make_export_image_widget, 'Image'),

--- a/nglview/sandbox/grid_view.py
+++ b/nglview/sandbox/grid_view.py
@@ -1,28 +1,31 @@
 from nglview.utils import js_utils
-from ipywidgets import GridBox, Layout # ipywidgets >= 7.3
+from ipywidgets import Button, GridBox, HBox, Layout # ipywidgets >= 7.3
+from nglview import NGLWidget
 from uuid import uuid4
 
 
-_code_fullscreen = """
+_code_set_size = """
 var ww = window.outerWidth
 var wh = window.outerHeight
 var vw = ww / %s + 'px'
 var vh = wh / %s + 50 + 'px'
 var pmodel =  this.model.widget_manager.get_model('%s')
-console.log(pmodel);
 
 pmodel.then(function(model){
     var key = Object.keys(model.views)[0];
     model.views[key].then(function(v){
-        console.log(v.el.style)
-        console.log(v.el.style)
         v.children_views.views.forEach(function(pv){
              pv.then(function(v){
-                 v.setSize(vw, vh);
+                 // v.setSize(vw, vh);
+                 console.log('do nothing');
              })
         })
     })
 })
+"""
+
+_code_esc_callback = """
+var pmodel =  this.model.widget_manager.get_model('%s')
 
 document.onkeydown = function(event){
     if (event.keyCode === 27){
@@ -57,12 +60,31 @@ class GridBoxNGL(GridBox):
         """           )
         n_rows = len(self.children) // self._n_columns
         n_columns = self._n_columns
-        code_fullscreen = _code_fullscreen % (n_columns, n_rows, self.model_id)
+        code_fullscreen = _code_set_size % (n_columns, n_rows, self.model_id) + _code_esc_callback
+        print(code_fullscreen)
         self.children[0]._execute_js_code(code_fullscreen)
 
         if js_code is not None:
             code += js_code
         js_utils.run(code)
+
+
+class GridBoxViewAndPlayer(GridBoxNGL):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._view = self.children[0]
+        self._player = self._view.player
+        self._player._create_all_widgets()
+        self._add_button_fullscreen()
+
+    def _add_button_fullscreen(self):
+        btn = Button(description='Fullscreen', icon='fullscreen')
+
+        def on_click(b):
+            self.fullscreen()
+        btn.on_click(on_click)
+
+        self._player.widget_general.children = list(self._player.widget_general.children) + [btn]
 
 
 def _sync_camera_pair(v0, v1):
@@ -80,20 +102,22 @@ def _sync_camera_pair(v0, v1):
 
 def _sync_all(views):
     from itertools import combinations
+    views = [v for v in views if isinstance(v, NGLWidget)]
     for v0, v1 in combinations(views, 2):
         _sync_camera_pair(v0, v1)
 
 
-def grid_view(views, n_columns, fullscreen=False, sync_camera=True):
+def grid_view(views, n_columns, grid_class=GridBoxViewAndPlayer, fullscreen=False, sync_camera=True,
+        **grid_kwargs):
     if sync_camera:
         _sync_all(views)
 
     grid_template_columns = f"{str(100 / n_columns)}% " * n_columns
-    box = GridBoxNGL(views,
-            layout=Layout(
-                grid_template_columns=grid_template_columns,
-                grid_spacing='0px 0px',
-                ))
+    grid_kwargs = grid_kwargs or {
+            'grid_template_columns': grid_template_columns,
+            'grid_spacing': '0px 0px'}
+    box = grid_class(views,
+            layout=Layout(**grid_kwargs))
     class_id = f"nglview-grid-{str(uuid4())}"
     box.add_class(class_id)
     box._n_columns = n_columns
@@ -104,3 +128,28 @@ def grid_view(views, n_columns, fullscreen=False, sync_camera=True):
 
         box.on_displayed(on_displayed)
     return box
+
+
+def fullscreen_mode(view):
+    player = view.player
+    player._create_all_widgets()
+    b = player._display()
+    b.layout.width = '400px'
+    b.layout.align_self = 'stretch'
+    bb = HBox([view, b])
+    class_id = f'nglview-{uuid4()}'
+    bb.add_class(class_id)
+
+    btn = Button(description='Fullscreen', icon='fullscreen')
+
+    def on_click(b):
+        view._execute_js_code("""
+        var ele = document.getElementsByClassName("%s")[0];
+
+        this.stage.viewer.container.style.height = window.screen.height + 'px'
+        console.log(window.innerHeight)
+        this.stage.toggleFullscreen(ele);
+        """ % class_id)
+    btn.on_click(on_click)
+    player.widget_general.children = list(player.widget_general.children) + [btn]
+    return bb

--- a/nglview/sandbox/grid_view.py
+++ b/nglview/sandbox/grid_view.py
@@ -16,8 +16,7 @@ pmodel.then(function(model){
     model.views[key].then(function(v){
         v.children_views.views.forEach(function(pv){
              pv.then(function(v){
-                 // v.setSize(vw, vh);
-                 console.log('do nothing');
+                 v.setSize(vw, vh);
              })
         })
     })
@@ -25,8 +24,6 @@ pmodel.then(function(model){
 """
 
 _code_esc_callback = """
-var pmodel =  this.model.widget_manager.get_model('%s')
-
 document.onkeydown = function(event){
     if (event.keyCode === 27){
         pmodel.then(function(model){
@@ -61,7 +58,6 @@ class GridBoxNGL(GridBox):
         n_rows = len(self.children) // self._n_columns
         n_columns = self._n_columns
         code_fullscreen = _code_set_size % (n_columns, n_rows, self.model_id) + _code_esc_callback
-        print(code_fullscreen)
         self.children[0]._execute_js_code(code_fullscreen)
 
         if js_code is not None:
@@ -136,7 +132,9 @@ def fullscreen_mode(view):
     b = player._display()
     b.layout.width = '400px'
     b.layout.align_self = 'stretch'
-    bb = HBox([view, b])
+    bb = GridBox([view, b],
+            layout=Layout(
+            grid_template_columns='70% 30%'))
     class_id = f'nglview-{uuid4()}'
     bb.add_class(class_id)
 

--- a/nglview/tests/test_widget.py
+++ b/nglview/tests/test_widget.py
@@ -218,7 +218,6 @@ def test_API_promise_to_have():
     view.display(gui=True, use_box=True)
     view._set_sync_frame()
     view._set_sync_camera()
-    view._set_spin([0, 1, 0], 0.5)
     view._set_selection('.CA')
     view.color_by('atomindex')
     representations = [dict(type='cartoon', params=dict())]
@@ -858,26 +857,10 @@ def test_player_simple():
     player._make_resize_notebook_slider()
     player._make_button_export_image()
     player._make_repr_playground()
-    player._make_spin_box()
     player._make_widget_picked()
     player._make_export_image_widget()
     player._make_general_box()
     player._update_padding()
-    player.spin = True
-    player._on_spin_changed(change=dict(new=True))
-    player._on_spin_x_changed(change=dict(new=1))
-    player._on_spin_y_changed(change=dict(new=1))
-    player._on_spin_z_changed(change=dict(new=1))
-    player._on_spin_speed_changed(change=dict(new=0.5))
-    player._spin_x = 2
-    player._spin_y = 2
-    player._spin_z = 2
-    player.spin = False
-    player._on_spin_changed(change=dict(new=True))
-    player._on_spin_x_changed(change=dict(new=1))
-    player._on_spin_y_changed(change=dict(new=1))
-    player._on_spin_z_changed(change=dict(new=1))
-    player._on_spin_speed_changed(change=dict(new=0.5))
     player._real_time_update = True
     player._make_widget_repr()
     player.widget_component_slider


### PR DESCRIPTION
Absolutely a sandbox code 

```
from nglview.sandbox.grid_view import fullscreen_mode

fullscreen_mode(view) # will add a `Fullscreen` button to the player
```

<img width="1023" alt="Screen Shot 2019-06-20 at 1 20 41 AM" src="https://user-images.githubusercontent.com/4451957/59822012-b2747780-92f9-11e9-8be2-aaa8e45e90c8.png">
