### PR TITLE
contrib.movie.MovieMaker.make() should call perframe_hook if specified

### DIFF
--- a/nglview/contrib/movie.py
+++ b/nglview/contrib/movie.py
@@ -80,9 +80,9 @@ class MovieMaker:
 
     Requires
     --------
-    
+
     moviepy. e.g:
-    
+
         pip install moviepy
         conda install freeimage
 
@@ -195,9 +195,9 @@ class MovieMaker:
         self.thread.daemon = True
         self.thread.start()
         return progress
-    
+
     def make(self, movie=True, keep_data=False):
-        """ 
+        """
 
         Parameters
         ----------
@@ -220,6 +220,8 @@ class MovieMaker:
                     frame = next(iframe)
                     self.view._set_coordinates(frame, movie_making=True,
                             render_params=self.render_params)
+                    if self.perframe_hook:
+                        self.perframe_hook(self.view)
                     self._progress.value = frame
                 except StopIteration:
                     self._progress.description = 'Making...'

--- a/nglview/contrib/movie.py
+++ b/nglview/contrib/movie.py
@@ -220,6 +220,7 @@ class MovieMaker:
                     frame = next(iframe)
                     self.view._set_coordinates(frame, movie_making=True,
                             render_params=self.render_params)
+                    self.view.frame = frame
                     if self.perframe_hook:
                         self.perframe_hook(self.view)
                     self._progress.value = frame


### PR DESCRIPTION
I noticed that `nglview.contrib.movie.MovieMaker.make()` does not call the user-specified `perframe_hook` if one is specified. This appears to be an accidental omission, since it appears in `.make_old_impl()`. This PR ensures this is called, with `view.frame` updated to the appropriate frame number before it is passed to the hook.