### PR TITLE
NGLWidget.add_component now tries to convert suitable objects

### DIFF
--- a/nglview/adaptor.py
+++ b/nglview/adaptor.py
@@ -81,6 +81,7 @@ class TextStructure(Structure):
         return self._text
 
 
+@register_backend('rdkit')
 class RdkitStructure(Structure):
     def __init__(self, rdkit_mol, ext="pdb"):
         super().__init__()

--- a/nglview/widget.py
+++ b/nglview/widget.py
@@ -1183,7 +1183,7 @@ class NGLWidget(DOMWidget):
         # if passed a supported object, convert "filename" to nglview.Trajectory
         try:
             package_name = filename.__module__.split('.')[0]
-        except TypeError:
+        except (TypeError, AttributeError):
             # string filename
             pass
         else:

--- a/nglview/widget.py
+++ b/nglview/widget.py
@@ -1110,8 +1110,9 @@ class NGLWidget(DOMWidget):
 
         Parameters
         ----------
-        trajectory: nglview.Trajectory or its derived class or 
-            pytraj.Trajectory-like, mdtraj.Trajectory or MDAnalysis objects
+        trajectory: nglview.Trajectory or its derived class or
+            a supported object, eg pytraj.Trajectory-like,
+            mdtraj.Trajectory, MDAnalysis objects, etc
 
         See Also
         --------
@@ -1179,6 +1180,16 @@ class NGLWidget(DOMWidget):
         If you want to load binary file such as density data, mmtf format, it is
         faster to load file from current or subfolder.
         '''
+        # if passed a supported object, convert "filename" to nglview.Trajectory
+        try:
+            package_name = filename.__module__.split('.')[0]
+        except TypeError:
+            # string filename
+            pass
+        else:
+            if package_name in BACKENDS:
+                filename = BACKENDS[package_name](filename)
+
         self._load_data(filename, **kwargs)
         # assign an ID
         self._ngl_component_ids.append(str(uuid.uuid4()))


### PR DESCRIPTION
I've got a list of `rdkit.Mol`s I want to show, so currently I would have to do something like:

```python
for mol in mols:
    s = nv.RDKitStructure(mol)
    v.add_component(s)
```

This patch makes it so that `NGLWidget.add_component` will try and use the `BACKENDS` register to figure out foreign objects