### PR TITLE
Don't advertise support for older Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -229,8 +229,6 @@ setup_args = {
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: JavaScript',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3 :: Only',


### PR DESCRIPTION
380c82be01aafc7c1351a33f05d870d8ea2480cd added a `python_reqiures` of >= 3.6, but the classifiers are still checked when determining which Python versions are supported. Without this change, `python3.5 -m pip install nglview` still allows me to install the package without warnings.