### PR TITLE
Added two optional keyword arguments to show_rdkit()

### DIFF
--- a/nglview/adaptor.py
+++ b/nglview/adaptor.py
@@ -83,17 +83,19 @@ class TextStructure(Structure):
 
 @register_backend('rdkit')
 class RdkitStructure(Structure):
-    def __init__(self, rdkit_mol, ext="pdb"):
+    def __init__(self, rdkit_mol, ext="pdb", conf_id=-1):
         super().__init__()
         self.path = ''
         self.ext = ext
+        self._conf_id = conf_id
         self.params = {}
         self._rdkit_mol = rdkit_mol
 
     def get_structure_string(self):
         from rdkit import Chem
 
-        return Chem.MolToPDBBlock(self._rdkit_mol)
+        reader = Chem.MolToPDBBlock if self.ext == "pdb" else Chem.MolToMolBlock
+        return reader(self._rdkit_mol, confId=self._conf_id)
 
 
 class PdbIdStructure(Structure):

--- a/nglview/adaptor.py
+++ b/nglview/adaptor.py
@@ -94,7 +94,8 @@ class RdkitStructure(Structure):
     def get_structure_string(self):
         from rdkit import Chem
 
-        reader = Chem.MolToPDBBlock if self.ext == "pdb" else Chem.MolToMolBlock
+        reader = (self.ext == "pdb") and \
+                 Chem.MolToPDBBlock or Chem.MolToMolBlock
         return reader(self._rdkit_mol, confId=self._conf_id)
 
 

--- a/nglview/show.py
+++ b/nglview/show.py
@@ -8,6 +8,7 @@ from .adaptor import (ASEStructure, ASETrajectory, BiopythonStructure,
                       ProdyStructure, ProdyTrajectory, PyTrajTrajectory,
                       QCelementalStructure, RosettaStructure,
                       SchrodingerStructure, SchrodingerTrajectory,
+                      RdkitStructure,
                       TextStructure)
 from .widget import NGLWidget
 
@@ -367,40 +368,10 @@ def show_rdkit(rdkit_mol, **kwargs):
     >>> # load as trajectory, need to have ParmEd
     >>> view = nv.show_rdkit(m, parmed=True) # doctest: +SKIP
     '''
-    from rdkit import Chem
-    confId = kwargs.pop("confId", -1)
-    try:
-        fmt = kwargs.pop("fmt")
-    except KeyError:
-        if rdkit_mol.GetNumAtoms() and rdkit_mol.GetAtomWithIdx(0).GetPDBResidueInfo():
-            fmt = "pdb"
-        else:
-            fmt = "sdf"
-    reader = Chem.MolToPDBBlock if fmt == "pdb" else Chem.MolToMolBlock
-    fh = StringIO(reader(rdkit_mol, confId=confId))
-
-    try:
-        use_parmed = kwargs.pop("parmed")
-    except KeyError:
-        use_parmed = False
-
-    if not use_parmed:
-        view = NGLWidget()
-        view.add_component(fh, ext=fmt, **kwargs)
-        return view
-    else:
-        import parmed as pmd
-        parm = pmd.load_rdkit(rdkit_mol)
-        parm_nv = ParmEdTrajectory(parm)
-
-        # set option for ParmEd
-        parm_nv.only_save_1st_model = False
-
-        # set option for NGL
-        # wait for: https://github.com/arose/ngl/issues/126
-        # to be fixed in NGLView
-        # parm_nv.params = dict(firstModelOnly=True)
-        return NGLWidget(parm_nv, **kwargs)
+    ext = kwargs.pop("fmt", "pdb")
+    conf_id = kwargs.pop("conf_id", -1)
+    struc = RdkitStructure(rdkit_mol, ext=ext, conf_id=conf_id)
+    return  NGLWidget(struc, **kwargs)
 
 
 def show_mdanalysis(atomgroup, **kwargs):

--- a/nglview/show.py
+++ b/nglview/show.py
@@ -337,8 +337,9 @@ def show_rdkit(rdkit_mol, **kwargs):
     ----------
     rdkit_mol : rdkit.Chem.rdchem.Mol
     kwargs : additional keyword argument
-    If kwargs contains the "confId" key, this will be passed to the
-    RDKit Chem.MolToXXXBlock function as a parameter.
+    If kwargs contains the "conf_id" key, this will be passed to the
+    RDKit Chem.MolToXXXBlock function as the confId parameter.
+    If the "conf_id" key is not provided, -1 will be used as confId.
     If kwargs contains the "fmt" key, this will be used to decide
     whether rdkit_mol should be visualized as a PDB block (fmt == "pdb")
     or as a SDF block (fmt == "sdf").
@@ -367,18 +368,16 @@ def show_rdkit(rdkit_mol, **kwargs):
     >>> view = nv.show_rdkit(m, parmed=True) # doctest: +SKIP
     '''
     from rdkit import Chem
-    try:
-        confId = kwargs.pop("confId")
-    except KeyError:
-        confId = -1
+    confId = kwargs.pop("confId", -1)
     try:
         fmt = kwargs.pop("fmt")
     except KeyError:
-        has_residue_info = (rdkit_mol.GetNumAtoms() and
-            rdkit_mol.GetAtomWithIdx(0).GetPDBResidueInfo())
-        fmt = "pdb" if has_residue_info else "sdf"
-    mol_read_fn = Chem.MolToPDBBlock if fmt == "pdb" else Chem.MolToMolBlock
-    fh = StringIO(mol_read_fn(rdkit_mol, confId=confId))
+        if rdkit_mol.GetNumAtoms() and rdkit_mol.GetAtomWithIdx(0).GetPDBResidueInfo():
+            fmt = "pdb"
+        else:
+            fmt = "sdf"
+    reader = Chem.MolToPDBBlock if fmt == "pdb" else Chem.MolToMolBlock
+    fh = StringIO(reader(rdkit_mol, confId=confId))
 
     try:
         use_parmed = kwargs.pop("parmed")

--- a/nglview/tests/test_widget.py
+++ b/nglview/tests/test_widget.py
@@ -592,8 +592,16 @@ def test_show_rdkit():
     assert not view._trajlist
     view = nv.show_rdkit(rdkit_mol, parmed=True)
     assert view._trajlist
-
-    view = nv.RdkitStructure(rdkit_mol)
+    structure = nv.RdkitStructure(rdkit_mol)
+    assert "HETATM" in structure.get_structure_string()
+    structure = nv.RdkitStructure(rdkit_mol, ext="sdf")
+    assert "RDKit          3D" in structure.get_structure_string()
+    structure2 = nv.RdkitStructure(rdkit_mol, ext="sdf", conf_id=0)
+    assert "RDKit          3D" in structure2.get_structure_string()
+    assert structure.get_structure_string() == structure2.get_structure_string()
+    structure3 = nv.RdkitStructure(rdkit_mol, ext="sdf", conf_id=1)
+    assert "RDKit          3D" in structure3.get_structure_string()
+    assert structure.get_structure_string() != structure3.get_structure_string()
 
 
 def test_encode_and_decode():

--- a/nglview/widget.py
+++ b/nglview/widget.py
@@ -159,7 +159,7 @@ class NGLWidget(DOMWidget):
     _camera_orientation = List().tag(sync=True)
     _synced_model_ids = List().tag(sync=True)
     _synced_repr_model_ids = List().tag(sync=True)
-    _ngl_view_id = List(Unicode).tag(sync=True)
+    _ngl_view_id = List().tag(sync=True)
     _ngl_repr_dict = Dict().tag(sync=True)
     _ngl_component_ids = List().tag(sync=False)
     _ngl_component_names = List().tag(sync=False)


### PR DESCRIPTION
- added an optional `confId` keyword argument to `show_rdkit()`
- added an optional `fmt` keyword argument to `show_rdkit()`; if `fmt` is not provided, a simple heuristic is used to guess if the RDKit molecule should be converted to a SDF or a PDB block